### PR TITLE
Fix timer reset after first tick

### DIFF
--- a/src/components/CategoryCard.tsx
+++ b/src/components/CategoryCard.tsx
@@ -60,23 +60,23 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
 
   React.useEffect(() => {
     timerFavorHook.setNewTime(category.timeFavor);
-  }, [category.timeFavor, timerFavorHook.setNewTime]);
+  }, [category.timeFavor]);
 
   React.useEffect(() => {
     timerContraHook.setNewTime(category.timeContra);
-  }, [category.timeContra, timerContraHook.setNewTime]);
+  }, [category.timeContra]);
 
   React.useEffect(() => {
     if (category.timeExamenCruzadoFavor !== undefined) {
       timerExamenFavorHook.setNewTime(category.timeExamenCruzadoFavor);
     }
-  }, [category.timeExamenCruzadoFavor, timerExamenFavorHook.setNewTime]);
+  }, [category.timeExamenCruzadoFavor]);
 
   React.useEffect(() => {
     if (category.timeExamenCruzadoContra !== undefined) {
       timerExamenContraHook.setNewTime(category.timeExamenCruzadoContra);
     }
-  }, [category.timeExamenCruzadoContra, timerExamenContraHook.setNewTime]);
+  }, [category.timeExamenCruzadoContra]);
   
   const handleQuestionToggle = (position: 'favor' | 'contra', questionId: string) => {
     // Note: Question state is per category, not per position (favor/contra) for refutations.

--- a/src/hooks/useDebateTimer.ts
+++ b/src/hooks/useDebateTimer.ts
@@ -37,9 +37,6 @@ export const useDebateTimer = ({
     isRunning: chronometer.isRunning,
     startPause: chronometer.toggleTimer,
     reset: chronometer.resetTimer,
-    setNewTime: (newTimeSeconds: number) => {
-      // This would need to be implemented in useChronometer if needed
-      chronometer.resetTimer();
-    }
+    setNewTime: chronometer.setNewTime
   };
 };


### PR DESCRIPTION
## Summary
- maintain timer duration as state so it can be updated
- implement and expose `setNewTime` in `useChronometer`
- use the new method in `useDebateTimer`
- prevent timer effects from re-triggering on every render

## Testing
- `npx tsc -p tsconfig.json` *(fails: `vite` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68449d738620833384e801bfd5a11a33