### PR TITLE
Add regression test for chronometer hook

### DIFF
--- a/src/__tests__/useChronometerRegression.test.ts
+++ b/src/__tests__/useChronometerRegression.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useChronometer } from '@/hooks/useChronometer';
+
+const mockPerformanceNow = vi.fn();
+Object.defineProperty(global, 'performance', {
+  value: { now: mockPerformanceNow },
+  writable: true
+});
+
+describe('useChronometer regression - timer continues after first second', () => {
+  let currentTime = 0;
+
+  beforeEach(() => {
+    currentTime = 0;
+    mockPerformanceNow.mockImplementation(() => currentTime);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps running beyond the initial second', () => {
+    const { result } = renderHook(() => useChronometer({ initialTime: 3 }));
+
+    act(() => {
+      result.current.startTimer();
+    });
+
+    // After 1 second it should still be running with about 2s remaining
+    currentTime = 1000;
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    expect(result.current.isRunning).toBe(true);
+    expect(result.current.time).toBe(2);
+
+    // After 2 seconds it should continue running with ~1s left
+    currentTime = 2000;
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    expect(result.current.isRunning).toBe(true);
+    expect(result.current.time).toBe(1);
+
+    // At 3 seconds it should stop
+    currentTime = 3000;
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.time).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the base chronometer hook keeps running after the first second

## Testing
- `npx vitest run --test-timeout 30000` *(fails: cannot find jsdom / test timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_6844a149a53c8333b352c109e7b17bc9