### PR TITLE
Allow timers to continue counting past zero

### DIFF
--- a/src/__tests__/TimerControl.test.tsx
+++ b/src/__tests__/TimerControl.test.tsx
@@ -106,21 +106,21 @@ describe('TimerControl handleStartPause edge case', () => {
 
     const worker: any = (global as any).latestWorker;
 
+    // Simulate time running past zero
     act(() => {
       worker.onmessage(
         new MessageEvent('message', {
-          data: { type: 'STOPPED', timerId: 'cat_favor', currentTime: 0, isRunning: false, drift: 0 }
+          data: { type: 'TICK', timerId: 'cat_favor', currentTime: -1, isRunning: true, drift: 0 }
         })
       );
     });
 
-    expect(toggle).toHaveAttribute('aria-label', 'Reanudar');
+    expect(toggle).toHaveAttribute('aria-label', 'Pausar');
 
     act(() => {
-      fireEvent.click(toggle); // should reset and start
+      fireEvent.click(toggle); // pause when time is negative
     });
 
-    expect(toggle).toHaveAttribute('aria-label', 'Pausar');
-    expect(screen.getByText('0:05')).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-label', 'Reanudar');
   });
 });

--- a/src/__tests__/useChronometerWorker.stability.test.tsx
+++ b/src/__tests__/useChronometerWorker.stability.test.tsx
@@ -35,15 +35,15 @@ class MockWorker {
   }
 
   simulateTick() {
-    this.currentTime = Math.max(0, this.currentTime - 1);
+    this.currentTime = this.currentTime - 1;
     if (this.onmessage) {
       this.onmessage(
         new MessageEvent('message', {
           data: {
-            type: this.currentTime > 0 ? 'TICK' : 'STOPPED',
+            type: 'TICK',
             timerId: this.timerId,
             currentTime: this.currentTime,
-            isRunning: this.currentTime > 0,
+            isRunning: true,
             drift: 0
           }
         })

--- a/src/hooks/useChronometer.ts
+++ b/src/hooks/useChronometer.ts
@@ -28,6 +28,8 @@ export const useChronometer = ({
   const elapsedMsRef = useRef<number>(0);
 
   // Tick function
+  const prevRemainingRef = useRef(durationMs);
+
   const tick = useCallback(() => {
     if (startTimestampRef.current === null) return;
 
@@ -37,12 +39,12 @@ export const useChronometer = ({
 
     const remainingMs = durationMs - delta;
 
-    if (remainingMs <= 0) {
-      setRemainingMs(0);
-      stopTimer();
+    // Fire onComplete once when crossing zero
+    if (prevRemainingRef.current > 0 && remainingMs <= 0) {
       onComplete?.();
-      return;
     }
+
+    prevRemainingRef.current = remainingMs;
 
     setRemainingMs(remainingMs);
     onTick?.(Math.ceil(remainingMs / 1000));

--- a/src/workers/chronometerWorker.ts
+++ b/src/workers/chronometerWorker.ts
@@ -52,33 +52,19 @@ class ChronometerWorker {
       const rawElapsedMs = now - timer.startTimestamp;
       const elapsedMs = rawElapsedMs - timer.pausedTimeMs;
       
-      // Calculate remaining time in milliseconds
-      const remainingMs = Math.max(0, timer.initialTimeMs - elapsedMs);
-      
+      // Calculate remaining time in milliseconds (allow negatives)
+      const remainingMs = timer.initialTimeMs - elapsedMs;
+
       // Update timer state
       timer.currentTimeMs = remainingMs;
-      
+
       // Convert to seconds for display
       const currentTimeSeconds = remainingMs / 1000;
       
       // Calculate drift (minimal for this implementation)
       const drift = 0;
       
-      // Auto-stop when time expires
-      if (remainingMs <= 0) {
-        timer.isRunning = false;
-        
-        postMessage({
-          type: 'STOPPED',
-          timerId: timer.id,
-          currentTime: 0,
-          isRunning: false,
-          drift: 0
-        } as TimerResponse);
-        continue;
-      }
-      
-      // Send normal tick update
+      // Always post TICK updates, even past zero
       postMessage({
         type: 'TICK',
         timerId: timer.id,


### PR DESCRIPTION
## Summary
- keep `useChronometer` running into negative time and fire `onComplete` only once
- keep worker posting `TICK` updates even after time elapses
- adapt tests for negative time handling

## Testing
- `npx vitest --version` *(fails: Need to install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6844b01f67a483339e2036891e6899cd