### PR TITLE
Add negative time warnings

### DIFF
--- a/src/__tests__/TimerControl.test.tsx
+++ b/src/__tests__/TimerControl.test.tsx
@@ -124,3 +124,45 @@ describe('TimerControl handleStartPause edge case', () => {
     expect(screen.getByText('0:05')).toBeInTheDocument();
   });
 });
+
+describe('TimerDisplay negative time visuals', () => {
+  it('shows red text and pale red background when time below threshold', () => {
+    const customSettings: GlobalSettings = {
+      ...settings,
+      negativeWarningThreshold: -5
+    };
+
+    render(
+      <AccessibilityProvider>
+        <TimerControl
+          initialTime={5}
+          categoryId="cat"
+          position="favor"
+          settings={customSettings}
+          baseBgColor="bg-white"
+          positionName="Favor"
+        />
+      </AccessibilityProvider>
+    );
+
+    const toggle = screen.getByRole('button', { name: /^Iniciar$/i });
+
+    act(() => {
+      fireEvent.click(toggle); // start
+    });
+
+    const worker: any = (global as any).latestWorker;
+
+    act(() => {
+      worker.onmessage(
+        new MessageEvent('message', {
+          data: { type: 'TICK', timerId: 'cat_favor', currentTime: -6, isRunning: true, drift: 0 }
+        })
+      );
+    });
+
+    const timeEl = screen.getByText('-0:06');
+    expect(timeEl).toHaveClass('text-red-800');
+    expect(timeEl.parentElement).toHaveClass('bg-soft-red');
+  });
+});

--- a/src/components/TimerControl.tsx
+++ b/src/components/TimerControl.tsx
@@ -112,6 +112,7 @@ const TimerControl: React.FC<TimerControlProps> = ({
         size={size}
         warningThreshold={settings.positiveWarningThreshold}
         criticalThreshold={Math.min(30, settings.positiveWarningThreshold / 2)}
+        negativeWarningThreshold={settings.negativeWarningThreshold}
       />
       
       <div className="mt-4">

--- a/src/components/TimerDisplay.tsx
+++ b/src/components/TimerDisplay.tsx
@@ -12,6 +12,7 @@ interface TimerDisplayProps {
   showProgress?: boolean;
   warningThreshold?: number;
   criticalThreshold?: number;
+  negativeWarningThreshold?: number;
 }
 
 const TimerDisplay: React.FC<TimerDisplayProps> = ({
@@ -22,24 +23,28 @@ const TimerDisplay: React.FC<TimerDisplayProps> = ({
   size = 'normal',
   showProgress = true,
   warningThreshold = 60,
-  criticalThreshold = 30
+  criticalThreshold = 30,
+  negativeWarningThreshold = -10
 }) => {
   const percentage = Math.max(0, (time / initialTime) * 100);
-  
+
   // Determine alert state
   const isWarning = time <= warningThreshold && time > criticalThreshold;
   const isCritical = time <= criticalThreshold && time > 0;
-  const isExpired = time <= 0;
+  const isExpired = time === 0;
+  const isNegative = time < 0;
+  const isNegativeWarning = time <= negativeWarningThreshold;
 
   // Style classes based on size
   const containerClasses = cn(
     'rounded-lg shadow-lg flex flex-col items-center space-y-4 transition-all duration-300',
     size === 'large' ? 'p-8 w-full max-w-md mx-auto' : 'p-6',
     {
-      'bg-card': !isWarning && !isCritical && !isExpired,
+      'bg-card': !isWarning && !isCritical && !isExpired && !isNegativeWarning,
       'bg-yellow-50 border-2 border-yellow-400': isWarning,
       'bg-red-50 border-2 border-red-400': isCritical,
       'bg-red-100 border-2 border-red-600': isExpired,
+      'bg-soft-red': isNegativeWarning,
       'animate-pulse': isRunning && (isCritical || isExpired)
     }
   );
@@ -53,10 +58,10 @@ const TimerDisplay: React.FC<TimerDisplayProps> = ({
     'font-mono font-bold tabular-nums',
     size === 'large' ? 'text-6xl md:text-7xl' : 'text-4xl',
     {
-      'text-foreground': !isWarning && !isCritical && !isExpired,
+      'text-foreground': !isWarning && !isCritical && !isExpired && !isNegative,
       'text-yellow-700': isWarning,
       'text-red-600': isCritical,
-      'text-red-800': isExpired
+      'text-red-800': isExpired || isNegative
     }
   );
 
@@ -79,7 +84,7 @@ const TimerDisplay: React.FC<TimerDisplayProps> = ({
                 {
                   'bg-green-500': !isWarning && !isCritical,
                   'bg-yellow-500': isWarning,
-                  'bg-red-500': isCritical || isExpired
+                  'bg-red-500': isCritical || isExpired || isNegative
                 }
               )}
               style={{ width: `${percentage}%` }}

--- a/src/hooks/useChronometerWorker.ts
+++ b/src/hooks/useChronometerWorker.ts
@@ -32,13 +32,8 @@ export const useChronometerWorker = ({
   const workerRef = useRef<Worker | null>(null);
   const onTickRef = useRef<typeof onTick>();
   const updateTimerState = useChronometerStore(state => state.updateTimerState);
-  const onTickRef = useRef<typeof onTick>();
 
   // Keep latest onTick callback without reinitializing worker
-  useEffect(() => {
-    onTickRef.current = onTick;
-  }, [onTick]);
-
   useEffect(() => {
     onTickRef.current = onTick;
   }, [onTick]);


### PR DESCRIPTION
## Summary
- ensure `useChronometerWorker` doesn't declare `onTickRef` twice
- highlight elapsed time in `TimerDisplay` when it goes negative
- forward negative warning threshold from `TimerControl`
- test negative time visuals for `TimerDisplay`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844b01f72448333974ecaac81a47037