### PR TITLE
Remove critical timer threshold

### DIFF
--- a/src/components/TimerControl.tsx
+++ b/src/components/TimerControl.tsx
@@ -111,7 +111,6 @@ const TimerControl: React.FC<TimerControlProps> = ({
         title={positionName}
         size={size}
         warningThreshold={settings.positiveWarningThreshold}
-        criticalThreshold={Math.min(30, settings.positiveWarningThreshold / 2)}
       />
       
       <div className="mt-4">

--- a/src/components/TimerDisplay.tsx
+++ b/src/components/TimerDisplay.tsx
@@ -11,7 +11,6 @@ interface TimerDisplayProps {
   size?: 'normal' | 'large';
   showProgress?: boolean;
   warningThreshold?: number;
-  criticalThreshold?: number;
 }
 
 const TimerDisplay: React.FC<TimerDisplayProps> = ({
@@ -21,14 +20,12 @@ const TimerDisplay: React.FC<TimerDisplayProps> = ({
   title,
   size = 'normal',
   showProgress = true,
-  warningThreshold = 60,
-  criticalThreshold = 30
+  warningThreshold = 60
 }) => {
   const percentage = Math.max(0, (time / initialTime) * 100);
   
   // Determine alert state
-  const isWarning = time <= warningThreshold && time > criticalThreshold;
-  const isCritical = time <= criticalThreshold && time > 0;
+  const isWarning = time <= warningThreshold && time > 0;
   const isExpired = time <= 0;
 
   // Style classes based on size
@@ -36,11 +33,10 @@ const TimerDisplay: React.FC<TimerDisplayProps> = ({
     'rounded-lg shadow-lg flex flex-col items-center space-y-4 transition-all duration-300',
     size === 'large' ? 'p-8 w-full max-w-md mx-auto' : 'p-6',
     {
-      'bg-card': !isWarning && !isCritical && !isExpired,
+      'bg-card': !isWarning && !isExpired,
       'bg-yellow-50 border-2 border-yellow-400': isWarning,
-      'bg-red-50 border-2 border-red-400': isCritical,
       'bg-red-100 border-2 border-red-600': isExpired,
-      'animate-pulse': isRunning && (isCritical || isExpired)
+      'animate-pulse': isRunning && isExpired
     }
   );
 
@@ -53,9 +49,8 @@ const TimerDisplay: React.FC<TimerDisplayProps> = ({
     'font-mono font-bold tabular-nums',
     size === 'large' ? 'text-6xl md:text-7xl' : 'text-4xl',
     {
-      'text-foreground': !isWarning && !isCritical && !isExpired,
+      'text-foreground': !isWarning && !isExpired,
       'text-yellow-700': isWarning,
-      'text-red-600': isCritical,
       'text-red-800': isExpired
     }
   );
@@ -77,9 +72,9 @@ const TimerDisplay: React.FC<TimerDisplayProps> = ({
               className={cn(
                 'h-full transition-all duration-1000 ease-linear',
                 {
-                  'bg-green-500': !isWarning && !isCritical,
+                  'bg-green-500': !isWarning && !isExpired,
                   'bg-yellow-500': isWarning,
-                  'bg-red-500': isCritical || isExpired
+                  'bg-red-500': isExpired
                 }
               )}
               style={{ width: `${percentage}%` }}

--- a/src/hooks/useChronometerWorker.ts
+++ b/src/hooks/useChronometerWorker.ts
@@ -32,13 +32,8 @@ export const useChronometerWorker = ({
   const workerRef = useRef<Worker | null>(null);
   const onTickRef = useRef<typeof onTick>();
   const updateTimerState = useChronometerStore(state => state.updateTimerState);
-  const onTickRef = useRef<typeof onTick>();
 
   // Keep latest onTick callback without reinitializing worker
-  useEffect(() => {
-    onTickRef.current = onTick;
-  }, [onTick]);
-
   useEffect(() => {
     onTickRef.current = onTick;
   }, [onTick]);


### PR DESCRIPTION
## Summary
- clean up timer display thresholds
- drop `criticalThreshold` from timer control
- remove duplicate `onTickRef` handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844b01eb0b8833399ba93b17e4eac75