### PR TITLE
Remove console log from timer handler

### DIFF
--- a/src/components/CategoryDetail.tsx
+++ b/src/components/CategoryDetail.tsx
@@ -20,6 +20,7 @@ import CategoryCard from './CategoryCard';
 import TimerControl from './TimerControl';
 import { v4 as uuidv4 } from 'uuid';
 import QuestionTracker from './QuestionTracker';
+import { useChronometerStore } from '@/stores/chronometerStore';
 
 interface CategoryDetailProps {
   category: CategoryConfig;
@@ -61,10 +62,15 @@ const CategoryDetail: React.FC<CategoryDetailProps> = ({
     onQuestionUpdate(category.id, [...category.questions, newQuestion]);
   };
 
-  // Handle timer updates (can be a no-op since we're using Zustand store)
+  // Handle timer updates
+  const updateTimerState = useChronometerStore(state => state.updateTimerState);
+
   const handleTimerUpdate = (payload: TimerUpdatePayload) => {
-    // Timer updates are now handled by the Zustand store
-    console.log('Timer update:', payload);
+    updateTimerState(payload.id, {
+      id: payload.id,
+      currentTime: payload.currentTime,
+      isRunning: payload.isRunning
+    });
   };
 
   const renderQuestionTracker = () => {


### PR DESCRIPTION
## Summary
- update CategoryDetail to use chronometer store updates in `handleTimerUpdate` instead of logging to console

## Testing
- `npx vitest run` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844b245b59c83339d6a2bc7a9168ac7