### PR TITLE
Add custom error handling to chronometer hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ browser or provide a polyfill to enable worker support. See
 [`src/hooks/useChronometerWorker.ts`](src/hooks/useChronometerWorker.ts) for
 implementation details.
 
+### Custom Error Handling
+
+`useChronometerWorker` accepts an optional `onError` callback. When provided,
+any worker-related exceptions are forwarded to this function instead of being
+logged with `console.error`. Use it to surface issues via a toast or other UI.
+
 ## 🧪 Testing
 
 ```bash


### PR DESCRIPTION
## Summary
- refactor `useChronometerWorker` to support `onError` callback
- forward worker errors through the new callback instead of always logging
- remove duplicate code in hook
- document custom error handling in README

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6844b2465f3883338fe0c0cdd22ea417