### PR TITLE
Fix chronometer worker message destructuring

### DIFF
--- a/src/hooks/useChronometerWorker.ts
+++ b/src/hooks/useChronometerWorker.ts
@@ -48,7 +48,7 @@ export const useChronometerWorker = ({
         );
 
         workerRef.current.onmessage = (event) => {
-          const { type, timerId: responseTimerId, currentTime, isRunning: workerIsRunning, drift: workerDrift } = event.data;
+          const { type, timerId: responseTimerId, currentTime, drift: workerDrift } = event.data;
           
           if (responseTimerId === timerId) {
             setTime(currentTime);


### PR DESCRIPTION
## Summary
- remove unused `workerIsRunning` property from the message handler in `useChronometerWorker`

## Testing
- `npm test` *(fails: TimerControl handleStartPause edge case)*
- `npm run lint` *(fails with multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6844b562f04483339803b8cc8dd580bc