### PR TITLE
Improve timer text size and color

### DIFF
--- a/src/__tests__/TimerControl.test.tsx
+++ b/src/__tests__/TimerControl.test.tsx
@@ -166,7 +166,7 @@ describe('TimerDisplay negative time visuals', () => {
     });
 
     const timeEl = screen.getByText('-0:06');
-    expect(timeEl).toHaveClass('text-red-800');
+    expect(timeEl).toHaveClass('text-red-600');
     expect(timeEl.parentElement).toHaveClass('bg-soft-red');
   });
 });

--- a/src/components/DebateTimerDisplay.tsx
+++ b/src/components/DebateTimerDisplay.tsx
@@ -52,13 +52,13 @@ const DebateTimerDisplay: React.FC<DebateTimerDisplayProps> = ({
 
   if (size === 'large') {
     positionNameClasses += " text-3xl md:text-4xl mb-4";
-    timeValueClasses += " text-8xl md:text-9xl";
+    timeValueClasses += " text-[12rem] md:text-[16rem]";
     iconSizeClass = "h-8 w-8 md:h-10 md:h-10";
     buttonSize = "lg";
     timeDigitsContainerClasses = "p-4 md:p-6 rounded bg-transparent";
   } else {
     positionNameClasses += " text-xl";
-    timeValueClasses += " text-6xl";
+    timeValueClasses += " text-[7.5rem]";
   }
 
   // Determine alert states and corresponding classes
@@ -66,13 +66,13 @@ const DebateTimerDisplay: React.FC<DebateTimerDisplayProps> = ({
     mainContainerAlertBgClass = "animate-yellow-blink"; 
     timeTextClasses = "text-black"; // Ensure contrast on yellow background
   } else if (time < 0) { // Any negative time
-    timeTextClasses = "text-strong-red"; // Text turns red for any negative time
+    timeTextClasses = "text-red-600"; // Text turns red for any negative time
     if (time < settings.negativeWarningThreshold) { // Negative time AND past the threshold
       mainContainerAlertBgClass = "bg-soft-red"; // Box turns pale red
     }
     // If time is negative but not past negativeWarningThreshold, 
     // mainContainerAlertBgClass remains empty, so box stays default color (white/card).
-    // timeTextClasses is already set to text-strong-red.
+    // timeTextClasses is already set to text-red-600.
   }
   // If none of the above (e.g. time is positive and above positiveWarningThreshold), 
   // mainContainerAlertBgClass and timeTextClasses remain empty (default appearance).

--- a/src/components/TimerDisplay.tsx
+++ b/src/components/TimerDisplay.tsx
@@ -61,11 +61,11 @@ const TimerDisplay: React.FC<TimerDisplayProps> = ({
   // Time text styling
   const timeClasses = cn(
     'font-mono font-bold tabular-nums',
-    size === 'large' ? 'text-6xl md:text-7xl' : 'text-4xl',
+    size === 'large' ? 'text-[7.5rem] md:text-[9rem]' : 'text-7xl',
     {
       'text-foreground': !isWarning && !isExpired && !isNegative,
       'text-yellow-700': isWarning,
-      'text-red-800': isExpired || isNegative,
+      'text-red-600': isExpired || isNegative,
     }
   )
 


### PR DESCRIPTION
## Summary
- enlarge timer text in TimerDisplay and DebateTimerDisplay
- show negative time in a medium red color
- update tests for new color

## Testing
- `npm install`
- `npm test` *(fails: Cannot access 'stopTimer' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_6844bd162b9c8333836ffa3445ed61e8