### PR TITLE
Make timer container responsive

### DIFF
--- a/src/components/DebateTimerDisplay.tsx
+++ b/src/components/DebateTimerDisplay.tsx
@@ -43,7 +43,7 @@ const DebateTimerDisplay: React.FC<DebateTimerDisplayProps> = ({
 }) => {
   let timeTextClasses = ""; 
   let positionNameClasses = "font-semibold";
-  let timeValueClasses = "font-bold";
+  let timeValueClasses = "font-bold whitespace-nowrap";
   let iconSizeClass = "h-6 w-6";
   let buttonSize: "icon" | "lg" = "icon";
   
@@ -84,7 +84,7 @@ const DebateTimerDisplay: React.FC<DebateTimerDisplayProps> = ({
         // Background only applies when an alert class is present
         mainContainerAlertBgClass,
         // Padding and layout classes
-        size === 'large' ? 'p-6 md:p-8 w-full max-w-md mx-auto' : 'p-4'
+        size === 'large' ? 'p-6 md:p-8 w-fit mx-auto inline-block' : 'p-4 w-fit inline-block'
       )}
     >
       <h3 className={positionNameClasses}>{positionName}</h3>

--- a/src/components/TimerControl.tsx
+++ b/src/components/TimerControl.tsx
@@ -4,7 +4,7 @@
  * Copyright (c) 2025 Luis Martín Maíllo
  */
 
-import React, { useEffect, useCallback } from 'react';
+import React, { useEffect, useCallback, useState } from 'react';
 import { useChronometerWorker } from '@/hooks/useChronometerWorker';
 import { useAccessibility } from '@/components/AccessibilityProvider';
 import TimerDisplay from './TimerDisplay';
@@ -56,6 +56,8 @@ const TimerControl: React.FC<TimerControlProps> = ({
     onTick: handleTick
   });
 
+  const [hasStarted, setHasStarted] = useState(false);
+
   // Handle keyboard shortcuts via custom events
   useEffect(() => {
     const handleToggle = (event: CustomEvent) => {
@@ -65,8 +67,10 @@ const TimerControl: React.FC<TimerControlProps> = ({
         } else {
           if (time < initialTime) {
             resume();
+            setHasStarted(true);
           } else {
             start();
+            setHasStarted(true);
           }
         }
       }
@@ -75,6 +79,7 @@ const TimerControl: React.FC<TimerControlProps> = ({
     const handleReset = (event: CustomEvent) => {
       if (event.detail.categoryId === categoryId && event.detail.position === position) {
         reset();
+        setHasStarted(false);
       }
     };
 
@@ -94,17 +99,25 @@ const TimerControl: React.FC<TimerControlProps> = ({
       if (time <= 0) {
         reset();
         resume();
+        setHasStarted(true);
       } else if (time < initialTime) {
         resume();
+        setHasStarted(true);
       } else {
         start();
+        setHasStarted(true);
       }
     }
   };
 
+  const handleResetClick = () => {
+    reset();
+    setHasStarted(false);
+  };
+
   return (
     <div
-      className={`rounded-lg ${size === 'large' ? 'p-6 md:p-8 w-full max-w-md mx-auto' : 'p-4'}`}
+      className={`rounded-lg ${size === 'large' ? 'p-6 md:p-8 w-fit mx-auto inline-block' : 'p-4 w-fit inline-block'}`}
     >
       <TimerDisplay
         time={time}
@@ -119,9 +132,9 @@ const TimerControl: React.FC<TimerControlProps> = ({
       <div className="mt-4">
         <TimerControls
           isRunning={isRunning}
-          isPaused={time < initialTime && !isRunning}
+          isPaused={!isRunning && hasStarted}
           onToggle={handleStartPause}
-          onReset={reset}
+          onReset={handleResetClick}
           size={size}
         />
       </div>

--- a/src/components/TimerDisplay.tsx
+++ b/src/components/TimerDisplay.tsx
@@ -36,7 +36,7 @@ const TimerDisplay: React.FC<TimerDisplayProps> = ({
   // Container background / border / animation
   const containerClasses = cn(
     'rounded-lg flex flex-col items-center space-y-4 transition-all duration-300',
-    size === 'large' ? 'p-8 w-full max-w-md mx-auto' : 'p-6',
+    size === 'large' ? 'p-8 w-fit mx-auto inline-block' : 'p-6 w-fit inline-block',
     {
       // Default appearance (also used for negative time above threshold)
       'bg-card': !isWarning && !isExpired && !isNegativeWarning,
@@ -60,7 +60,7 @@ const TimerDisplay: React.FC<TimerDisplayProps> = ({
 
   // Time text styling
   const timeClasses = cn(
-    'font-mono font-bold tabular-nums',
+    'font-mono font-bold tabular-nums whitespace-nowrap',
     size === 'large' ? 'text-[7.5rem] md:text-[9rem]' : 'text-7xl',
     {
       'text-foreground': !isWarning && !isExpired && !isNegative,

--- a/src/hooks/useChronometer.ts
+++ b/src/hooks/useChronometer.ts
@@ -27,6 +27,19 @@ export const useChronometer = ({
   const intervalRef = useRef<number | null>(null);
   const elapsedMsRef = useRef<number>(0);
 
+  const stopTimer = useCallback(() => {
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+
+    setIsRunning(false);
+    setIsPaused(false);
+    elapsedMsRef.current = 0;
+    startTimestampRef.current = null;
+  }, []);
+
+
   // Tick function
   const prevRemainingRef = useRef(durationMs);
 
@@ -39,9 +52,12 @@ export const useChronometer = ({
 
     const remainingMs = durationMs - delta;
 
-    // Fire onComplete once when crossing zero
+    // Fire onComplete once and stop when crossing zero
     if (prevRemainingRef.current > 0 && remainingMs <= 0) {
       onComplete?.();
+      setRemainingMs(0);
+      stopTimer();
+      return;
     }
 
     prevRemainingRef.current = remainingMs;
@@ -83,17 +99,6 @@ export const useChronometer = ({
     startTimer();
   }, [isRunning, isPaused, startTimer]);
 
-  const stopTimer = useCallback(() => {
-    if (intervalRef.current !== null) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
-
-    setIsRunning(false);
-    setIsPaused(false);
-    elapsedMsRef.current = 0;
-    startTimestampRef.current = null;
-  }, []);
 
   const resetTimer = useCallback(() => {
     if (disabled) return;

--- a/src/pages/TimerPage.tsx
+++ b/src/pages/TimerPage.tsx
@@ -48,7 +48,7 @@ const TimerPage: React.FC<TimerPageProps> = ({
 
   return (
     <div className="min-h-screen bg-background flex flex-col items-center justify-center p-4">
-      <div className="w-full max-w-md mx-auto space-y-8">
+      <div className="w-fit mx-auto space-y-8 inline-block">
         <h1 className="text-3xl font-bold text-center">{title}</h1>
         
         <TimerDisplay


### PR DESCRIPTION
## Summary
- let timer containers expand with the digit size
- ensure chronometer stops at zero and controls react properly
- mark timers as started when toggled so the pause label works

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844bf62c9d08333b3c9c5b480f3f9f6